### PR TITLE
All remote songs

### DIFF
--- a/legacyLibraryProject/PlayerHater/project.properties
+++ b/legacyLibraryProject/PlayerHater/project.properties
@@ -23,5 +23,5 @@
 # project structure.
 
 # Project target.
-target=android-16
+target=android-18
 android.library=true

--- a/src/main/aidl/org/prx/playerhater/ipc/IPlayerHaterServer.aidl
+++ b/src/main/aidl/org/prx/playerhater/ipc/IPlayerHaterServer.aidl
@@ -39,10 +39,10 @@ interface IPlayerHaterServer {
     boolean stop();
     boolean resume();
     boolean playAtTime(int startTime);
-    boolean play(int songTag, int startTime);
+    boolean play(int songTag, in Bundle songData, int startTime);
     boolean seekTo(int startTime);
-    int enqueue(int songTag);
-    void enqueueAtPosition(int position, int songTag);
+    int enqueue(int songTag, in Bundle songData);
+    void enqueueAtPosition(int position, int songTag, in Bundle songData);
     boolean skipTo(int position);
     void skip();
     void skipBack();

--- a/src/main/java/org/prx/playerhater/ipc/PlayerHaterClient.java
+++ b/src/main/java/org/prx/playerhater/ipc/PlayerHaterClient.java
@@ -120,32 +120,32 @@ public class PlayerHaterClient extends IPlayerHaterClient.Stub {
 
 	@Override
 	public String getSongTitle(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getTitle();
+		return SongHost.getLocalSong(songTag).getTitle();
 	}
 
 	@Override
 	public String getSongArtist(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getArtist();
+		return SongHost.getLocalSong(songTag).getArtist();
 	}
 
 	@Override
 	public String getSongAlbumTitle(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getAlbumTitle();
+		return SongHost.getLocalSong(songTag).getAlbumTitle();
 	}
 
 	@Override
 	public Uri getSongAlbumArt(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getAlbumArt();
+		return SongHost.getLocalSong(songTag).getAlbumArt();
 	}
 
 	@Override
 	public Uri getSongUri(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getUri();
+		return SongHost.getLocalSong(songTag).getUri();
 	}
 
 	@Override
 	public Bundle getSongExtra(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getExtra();
+		return SongHost.getLocalSong(songTag).getExtra();
 	}
 
     @Override

--- a/src/main/java/org/prx/playerhater/ipc/PlayerHaterServer.java
+++ b/src/main/java/org/prx/playerhater/ipc/PlayerHaterServer.java
@@ -91,8 +91,8 @@ public class PlayerHaterServer extends IPlayerHaterServer.Stub {
 	}
 
 	@Override
-	public boolean play(int songTag, int startTime) throws RemoteException {
-		return mService.play(SongHost.getSong(songTag), startTime);
+	public boolean play(int songTag, Bundle songData, int startTime) throws RemoteException {
+		return mService.play(SongHost.getSong(songTag, songData), startTime);
 	}
 
 	@Override
@@ -101,14 +101,14 @@ public class PlayerHaterServer extends IPlayerHaterServer.Stub {
 	}
 
 	@Override
-	public int enqueue(int songTag) throws RemoteException {
-		return mService.enqueue(SongHost.getSong(songTag));
+	public int enqueue(int songTag, Bundle songData) throws RemoteException {
+		return mService.enqueue(SongHost.getSong(songTag, songData));
 	}
 
 	@Override
-	public void enqueueAtPosition(int position, int songTag)
+	public void enqueueAtPosition(int position, int songTag, Bundle songData)
 			throws RemoteException {
-		mService.enqueue(position, SongHost.getSong(songTag));
+		mService.enqueue(position, SongHost.getSong(songTag, songData));
 	}
 
 	@Override
@@ -184,32 +184,32 @@ public class PlayerHaterServer extends IPlayerHaterServer.Stub {
 
 	@Override
 	public String getSongTitle(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getTitle();
+		return SongHost.getLocalSong(songTag).getTitle();
 	}
 
 	@Override
 	public String getSongArtist(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getArtist();
+		return SongHost.getLocalSong(songTag).getArtist();
 	}
 
 	@Override
 	public String getSongAlbumTitle(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getAlbumTitle();
+		return SongHost.getLocalSong(songTag).getAlbumTitle();
 	}
 
 	@Override
 	public Uri getSongAlbumArt(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getAlbumArt();
+		return SongHost.getLocalSong(songTag).getAlbumArt();
 	}
 
 	@Override
 	public Uri getSongUri(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getUri();
+		return SongHost.getLocalSong(songTag).getUri();
 	}
 
 	@Override
 	public Bundle getSongExtra(int songTag) throws RemoteException {
-		return SongHost.getSong(songTag).getExtra();
+		return SongHost.getLocalSong(songTag).getExtra();
 	}
 
 	@Override

--- a/src/main/java/org/prx/playerhater/ipc/ServerPlayerHater.java
+++ b/src/main/java/org/prx/playerhater/ipc/ServerPlayerHater.java
@@ -18,6 +18,7 @@ package org.prx.playerhater.ipc;
 import org.prx.playerhater.PlayerHater;
 import org.prx.playerhater.Song;
 import org.prx.playerhater.songs.SongHost;
+import org.prx.playerhater.songs.Songs;
 import org.prx.playerhater.util.Log;
 
 import android.app.PendingIntent;
@@ -78,7 +79,7 @@ public class ServerPlayerHater extends PlayerHater {
 	@Override
 	public boolean play(Song song) {
 		try {
-			return mServer.play(SongHost.getTag(song), 0);
+			return mServer.play(SongHost.getTag(song), Songs.toBundle(song), 0);
 		} catch (RemoteException e) {
 			Log.e(SERVER_ERROR, e);
 			throw new IllegalStateException(SERVER_ERROR, e);
@@ -88,7 +89,7 @@ public class ServerPlayerHater extends PlayerHater {
 	@Override
 	public boolean play(Song song, int startTime) {
 		try {
-			return mServer.play(SongHost.getTag(song), startTime);
+			return mServer.play(SongHost.getTag(song), Songs.toBundle(song), startTime);
 		} catch (RemoteException e) {
 			Log.e(SERVER_ERROR, e);
 			throw new IllegalStateException(SERVER_ERROR, e);
@@ -108,7 +109,7 @@ public class ServerPlayerHater extends PlayerHater {
 	@Override
 	public int enqueue(Song song) {
 		try {
-			return mServer.enqueue(SongHost.getTag(song));
+			return mServer.enqueue(SongHost.getTag(song), Songs.toBundle(song));
 		} catch (RemoteException e) {
 			Log.e(SERVER_ERROR, e);
 			throw new IllegalStateException(SERVER_ERROR, e);
@@ -118,7 +119,7 @@ public class ServerPlayerHater extends PlayerHater {
 	@Override
 	public void enqueue(int position, Song song) {
 		try {
-			mServer.enqueueAtPosition(position, SongHost.getTag(song));
+			mServer.enqueueAtPosition(position, SongHost.getTag(song), Songs.toBundle(song));
 		} catch (RemoteException e) {
 			Log.e(SERVER_ERROR, e);
 			throw new IllegalStateException(SERVER_ERROR, e);

--- a/src/main/java/org/prx/playerhater/songs/RemoteSong.java
+++ b/src/main/java/org/prx/playerhater/songs/RemoteSong.java
@@ -29,6 +29,7 @@ class RemoteSong implements Song {
 
 	private final int mTag;
 	private Song mSong = null;
+	private static final String remoteSongExceptionMessage = "Remote Process has died or become disconnected and song data has not been copied";
 
 	RemoteSong(int tag) {
 		mTag = tag;
@@ -36,83 +37,81 @@ class RemoteSong implements Song {
 
 	@Override
 	public String getTitle() {
-		if (mSong != null) {
-			return mSong.getTitle();
-		}
 		try {
 			return getRemote().getSongTitle(mTag);
 		} catch (RemoteException e) {
-			throw new IllegalStateException(
-					"Remote Process has died or become disconnected", e);
+			if (mSong != null) {
+				return mSong.getTitle();
+			}
+			throw new IllegalStateException(remoteSongExceptionMessage, e);
 		}
 	}
 
 	@Override
 	public String getArtist() {
-		if (mSong != null) {
-			return mSong.getArtist();
-		}
 		try {
 			return getRemote().getSongArtist(mTag);
 		} catch (RemoteException e) {
-			throw new IllegalStateException(
-					"Remote Process has died or become disconnected", e);
+			if (mSong != null) {
+				return mSong.getArtist();
+			}
+			throw new IllegalStateException(remoteSongExceptionMessage, e);
 		}
 	}
 
 	@Override
 	public Uri getAlbumArt() {
-		if (mSong != null) {
-			return mSong.getAlbumArt();
-		}
 		try {
 			return getRemote().getSongAlbumArt(mTag);
 		} catch (RemoteException e) {
-			throw new IllegalStateException(
-					"Remote Process has died or become disconnected", e);
+			if (mSong != null) {
+				return mSong.getAlbumArt();
+			}
+			throw new IllegalStateException(remoteSongExceptionMessage, e);
 		}
 	}
 
 	@Override
 	public Uri getUri() {
-		if (mSong != null) {
-			return mSong.getUri();
-		}
 		try {
 			return getRemote().getSongUri(mTag);
 		} catch (RemoteException e) {
-			throw new IllegalStateException(
-					"Remote Process has died or become disconnected", e);
+			if (mSong != null) {
+				return mSong.getUri();
+			}
+			throw new IllegalStateException(remoteSongExceptionMessage, e);
 		}
 	}
 
 	@Override
 	public Bundle getExtra() {
-		if (mSong != null) {
-			return mSong.getExtra();
-		}
 		try {
 			return getRemote().getSongExtra(mTag);
 		} catch (RemoteException e) {
-			throw new IllegalStateException(
-					"Remote Process has died or become disconnected", e);
+			if (mSong != null) {
+				return mSong.getExtra();
+			}
+			throw new IllegalStateException(remoteSongExceptionMessage, e);
 		}
 	}
 
 	@Override
 	public String getAlbumTitle() {
-		if (mSong != null) {
-			return mSong.getAlbumTitle();
-		}
 		try {
 			return getRemote().getSongAlbumTitle(mTag);
 		} catch (RemoteException e) {
-			throw new IllegalStateException(
-					"Remote Process has died or become disconnected", e);
+			if (mSong != null) {
+				return mSong.getAlbumTitle();
+			}
+			throw new IllegalStateException(remoteSongExceptionMessage, e);
 		}
 	}
 
 	void setSong(Song song) {
 		mSong = song;
+	}
+	
+	Song getSong() { 
+		return mSong; 
 	}
 }

--- a/src/main/java/org/prx/playerhater/songs/SongHost.java
+++ b/src/main/java/org/prx/playerhater/songs/SongHost.java
@@ -47,10 +47,7 @@ public class SongHost {
 	}
 
 	public static void slurp(int songTag, Bundle songData) {
-		Song song = getSong(songTag);
-		if (song instanceof RemoteSong) {
-			((RemoteSong) getSong(songTag)).setSong(Songs.fromBundle(songData));
-		}
+		((RemoteSong) getSong(songTag)).setSong(Songs.fromBundle(songData));
 	}
 
 	public static SparseArray<Bundle> localSongs() {
@@ -80,21 +77,17 @@ public class SongHost {
 		if (song == null) {
 			return INVALID_TAG;
 		}
-		if (getTags().containsKey(song)) {
-			return getTags().get(song);
-		} else {
-			int tag = song.hashCode();
-			getTags().put(song, tag);
-			getSongs().put(tag, song);
-			return tag;
-		}
+		int tag = song.hashCode(); 
+		RemoteSong remote = getRemoteSong(tag); 
+		remote.setSong(Songs.fromBundle(Songs.toBundle(song))); 
+		return tag; 
 	}
-
-	public static Song getSong(int tag) {
+	
+	private static RemoteSong getRemoteSong(int tag) { 
 		if (tag == INVALID_TAG) {
 			return null;
 		}
-		Song song = getSongs().get(tag);
+		RemoteSong song = (RemoteSong) getSongs().get(tag);
 		if (song != null) {
 			return song;
 		} else {
@@ -103,6 +96,14 @@ public class SongHost {
 			getSongs().put(tag, song);
 			return song;
 		}
+	}
+
+	public static Song getSong(int tag) {
+		RemoteSong remote = getRemoteSong(tag); 
+		if (remote != null && remote.getSong() != null) { 
+			return remote.getSong(); 
+		}
+		return remote; 
 	}
 
 	private static SparseArray<Song> getSongs() {

--- a/src/main/java/org/prx/playerhater/songs/SongHost.java
+++ b/src/main/java/org/prx/playerhater/songs/SongHost.java
@@ -116,7 +116,10 @@ public class SongHost {
 	public static Song getLocalSong(int tag) { 
 		Song song = getSongs().get(tag); 
 		if (song instanceof RemoteSong) { 
-			return ((RemoteSong) song).getSong(); 
+			song = ((RemoteSong) song).getSong(); 
+		}
+		if (song == null) { 
+			throw new IllegalStateException("No locally stored song data available."); 
 		}
 		return song; 
 	}

--- a/src/main/java/org/prx/playerhater/songs/SongHost.java
+++ b/src/main/java/org/prx/playerhater/songs/SongHost.java
@@ -47,7 +47,10 @@ public class SongHost {
 	}
 
 	public static void slurp(int songTag, Bundle songData) {
-		((RemoteSong) getSong(songTag)).setSong(Songs.fromBundle(songData));
+		Song song = getSong(songTag);
+		if (song instanceof RemoteSong) {
+			((RemoteSong) getSong(songTag)).setSong(Songs.fromBundle(songData));
+		}
 	}
 
 	public static SparseArray<Bundle> localSongs() {
@@ -77,17 +80,21 @@ public class SongHost {
 		if (song == null) {
 			return INVALID_TAG;
 		}
-		int tag = song.hashCode(); 
-		RemoteSong remote = getRemoteSong(tag); 
-		remote.setSong(Songs.fromBundle(Songs.toBundle(song))); 
-		return tag; 
+		if (getTags().containsKey(song)) {
+			return getTags().get(song);
+		} else {
+			int tag = song.hashCode();
+			getTags().put(song, tag);
+			getSongs().put(tag, song);
+			return tag;
+		}
 	}
-	
-	private static RemoteSong getRemoteSong(int tag) { 
+
+	public static Song getSong(int tag) {
 		if (tag == INVALID_TAG) {
 			return null;
 		}
-		RemoteSong song = (RemoteSong) getSongs().get(tag);
+		Song song = getSongs().get(tag);
 		if (song != null) {
 			return song;
 		} else {
@@ -97,13 +104,21 @@ public class SongHost {
 			return song;
 		}
 	}
-
-	public static Song getSong(int tag) {
-		RemoteSong remote = getRemoteSong(tag); 
-		if (remote != null && remote.getSong() != null) { 
-			return remote.getSong(); 
+	
+	public static Song getSong(int tag, Bundle songData) { 
+		Song song = getSong(tag); 
+		if (song instanceof RemoteSong) { 
+			((RemoteSong) song).setSong(Songs.fromBundle(songData));
 		}
-		return remote; 
+		return song; 
+	}
+	
+	public static Song getLocalSong(int tag) { 
+		Song song = getSongs().get(tag); 
+		if (song instanceof RemoteSong) { 
+			return ((RemoteSong) song).getSong(); 
+		}
+		return song; 
 	}
 
 	private static SparseArray<Song> getSongs() {

--- a/src/main/java/org/prx/playerhater/wrappers/BoundPlayerHater.java
+++ b/src/main/java/org/prx/playerhater/wrappers/BoundPlayerHater.java
@@ -179,8 +179,7 @@ public class BoundPlayerHater extends PlayerHater {
 				try {
 					server.setClient(getPlayerHaterClient());
 				} catch (RemoteException e) {
-					throw new IllegalStateException("Server has gone away...",
-							e);
+					throw new IllegalStateException("Server has gone away...", e);
 				}
 
 				sPlayerHater = new ServerPlayerHater(server);


### PR DESCRIPTION
- When a song is played across IPC both the tag and bundled data are passed
- When a remote song is added to a song host a local copy of the song is created from bundled data
- When a data request is made over IPC it is requested only from a local song and throws an exception if no locally stored song data is available (this stops potential infinite loop of song hosts passing remote songs back and forth) 
- Allows the app and player hater to recover more gracefully if the app quits unexpectedly
